### PR TITLE
Convert rosbag to ros1 if ros2 bag passed SS-122

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A Calibration Framework using the <br><strong><span style="font-size: large">A</
 <!-- Font sizes here -->
 <!-- https://www.freecodecamp.org/news/html-font-size-how-to-change-text-size-using-inline-css-style/ -->
 
+> **NOTE:** for that fork to work properly, `rosbags` library from [here](https://github.com/cmrobotics/rosbags) is required.
+
 **ATOM** is a set of calibration tools for multi-sensor, multi-modal, robotic systems, based on the optimization of atomic transformations as provided by a [ROS](https://www.ros.org/) based robot description. Moreover, **ATOM** provides several scripts to facilitate all the steps of a calibration procedure.
 
 For instructions on how to install and use, **check the documentation**:

--- a/atom_calibration/scripts/configure_calibration_pkg
+++ b/atom_calibration/scripts/configure_calibration_pkg
@@ -26,6 +26,7 @@ import networkx as nx
 # local packages
 from atom_core.utilities import checkDirectoryExistence
 from atom_core.naming import generateLabeledTopic
+from atom_core.rosbag2 import is_rosbag2, convert_rosbag2_to_rosbag1
 from colorama import Style, Fore
 from graphviz import Digraph
 from urdf_parser_py.urdf import URDF
@@ -122,6 +123,17 @@ if __name__ == "__main__":
     # Read the bag file
     # --------------------------------------------------------------------------
     bag_file, _, bag_file_rel = atom_core.config_io.uriReader(config['bag_file'])
+    if is_rosbag2(bag_file):
+        print(f"{bag_file} is a rosbag2 file. Converting to rosbag1 format")
+        rosbag2_file = convert_rosbag2_to_rosbag1(bag_file)
+        if rosbag2_file:
+            print("Converted successfully, destination file: " + rosbag2_file)
+            bag_file = rosbag2_file
+            bag_file_rel = bag_file
+        else:
+            print('Error converting rosbag2 to rosbag1')
+            exit(1)
+
     print('Loading bagfile ' + bag_file)
     bag = rosbag.Bag(bag_file)
     bag_info = bag.get_type_and_topic_info()

--- a/atom_core/src/atom_core/rosbag2.py
+++ b/atom_core/src/atom_core/rosbag2.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+"""
+rosbag2 format utilities
+"""
+import os
+from pathlib import Path
+
+from rosbags.convert.converter import convert_2to1
+
+def is_rosbag2(bag_path: str):
+    """
+    Check if a file is a rosbag2 file.
+    :param path: path to the file
+
+    :return: True if the file is a rosbag2 file, False otherwise
+    """
+
+    if os.path.isdir(bag_path):        
+        metadata_file = os.path.join(bag_path, 'metadata.yaml')
+        if os.path.exists(metadata_file):
+            return True
+        
+    return False
+
+
+def convert_rosbag2_to_rosbag1(bag_path: str):
+    """
+    Convert a rosbag2 file to a rosbag1 file.
+    :param path: path to the file
+
+    :return: path to the converted file or empty string if the conversion failed
+    """
+
+    src_path = Path(bag_path)
+    dst_path = Path(bag_path).with_suffix('.bag')
+    if dst_path.exists():
+        print(f"Destination file already exists: {dst_path.as_posix()}. Aborting conversion.")
+    else:
+        try:
+            convert_2to1(src_path, dst_path, [], [])
+        except Exception as e:
+            print(e)
+            return ""
+        
+    return dst_path.as_posix()


### PR DESCRIPTION
## Purpose
We record data in ROS2, but the `Atom` framework works in ROS1. So we need conversion. The modified version of [rosbags](https://github.com/cmrobotics/rosbags) library is used for that.
In that PR I integrate conversion to the Atom, so it doesn't matter for Atom users which rosbag version is passed.

Here is the [link](https://cmrobotics.sharepoint.com/:w:/r/sites/ProductDevelopment/Documents/Software/Calibration/Camera%20Extrinsic%20Calibration.docx?d=w3c578901d6834d3fa9a3f644343c142a&csf=1&web=1&e=zUUTu4) to my documentation on camera calibration, if you want to get more info.
